### PR TITLE
Relax mustermann version in dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'support', git: 'git@github.com:sinatra/mustermann.git'
+gem 'support', git: 'https://github.com/sinatra/mustermann.git'
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,9 @@
 GIT
-  remote: git@github.com:sinatra/mustermann.git
-  revision: 4e7221d7fbcbc897e05fa088909caface9e7280e
+  remote: https://github.com/sinatra/mustermann.git
+  revision: db86e25f786c717dbe937d862a5ba0d35a58797b
   specs:
+    mustermann (1.1.0)
+      ruby2_keywords (~> 0.0.1)
     support (0.0.1)
       addressable
       coveralls
@@ -19,7 +21,7 @@ PATH
   remote: .
   specs:
     mustermann-grape (1.0.0)
-      mustermann (~> 1.0.0)
+      mustermann (>= 1.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -35,7 +37,6 @@ GEM
     diff-lcs (1.2.5)
     docile (1.1.5)
     json (2.0.2)
-    mustermann (1.0.0)
     public_suffix (2.0.3)
     rack (1.6.12)
     rack-protection (1.5.3)
@@ -60,6 +61,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
+    ruby2_keywords (0.0.1)
     simplecov (0.12.0)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)

--- a/mustermann-grape.gemspec
+++ b/mustermann-grape.gemspec
@@ -14,5 +14,5 @@ Gem::Specification.new do |s|
   s.files                 = `git ls-files`.split("\n")
   s.test_files            = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables           = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
-  s.add_dependency 'mustermann', '~> 1.0.0'
+  s.add_dependency 'mustermann', '>= 1.0.0'
 end


### PR DESCRIPTION
As we [already done](https://github.com/ruby-grape/grape/pull/1948) for Grape gem and _dry-types_ dependency - the same must be done for _mustermann_ dependency here because of new 1.1.0 release that has fixes for Ruby 2.7 kwargs ( https://github.com/sinatra/mustermann/pull/97/files ).

All specs are pass with a new version of mustermann:

![image](https://user-images.githubusercontent.com/1443426/71573191-a745a400-2af3-11ea-835a-bae0033cfe2a.png)

