### PR TITLE
bump version to 1.0.1

### DIFF
--- a/lib/mustermann/grape/version.rb
+++ b/lib/mustermann/grape/version.rb
@@ -2,6 +2,6 @@ require 'mustermann/grape'
 
 module Mustermann
   class Grape
-    VERSION = '1.0.0'
+    VERSION = '1.0.1'
   end
 end

--- a/mustermann-grape.gemspec
+++ b/mustermann-grape.gemspec
@@ -4,7 +4,7 @@ require "mustermann/grape/version"
 Gem::Specification.new do |s|
   s.name                  = "mustermann-grape"
   s.version               = Mustermann::Grape::VERSION
-  s.authors               = ["namusyaka", "Konstantin Haase"]
+  s.authors               = ["namusyaka", "Konstantin Haase", "Daniel Doubrovkine"]
   s.email                 = "namusyaka@gmail.com"
   s.homepage              = "https://github.com/ruby-grape/mustermann-grape"
   s.summary               = %q{Grape syntax for Mustermann}


### PR DESCRIPTION
In addition to this, I've just added @dblock as an owner for this gem.
https://rubygems.org/gems/mustermann-grape

@dblock Could you merge this change and cut a new release on rubygems?